### PR TITLE
ContactsCommon: Fix possible NPE

### DIFF
--- a/src/com/android/contacts/common/vcard/VCardService.java
+++ b/src/com/android/contacts/common/vcard/VCardService.java
@@ -162,7 +162,7 @@ public class VCardService extends Service {
             final ArrayList<String> uris = new ArrayList<String>();
             final ArrayList<String> displayNames = new ArrayList<String>();
             for (ImportRequest request : requests) {
-                uris.add(request.uri.toString());
+                uris.add(String.valueOf(request.uri));
                 displayNames.add(request.displayName);
             }
             Log.d(LOG_TAG,


### PR DESCRIPTION
* Importing a VCard via NFC creates ImportRequest objects with their uri
  being null
* Calling toString() on that uri causes an NPE
* Use String.valueOf() to get a String, not an exception
* This occurs because the DEBUG flag is always set, otherwise it would not
  occur anyway

BUGBASH-966

Change-Id: I1f7165dbe0327bd24d6f7f6fc9ebaa4b920019c4